### PR TITLE
Add more robust task cancellation, performance improvements for macOS

### DIFF
--- a/Sources/HeatMap/AnnularAssembly.swift
+++ b/Sources/HeatMap/AnnularAssembly.swift
@@ -50,7 +50,9 @@ enum AnnularAssembly {
         for (levelIndex, level) in sortedLevels.enumerated() {
             try Task.checkCancellation()
 
-            let outerPolygons = grouped[level]!
+            guard let outerPolygons = grouped[level] else {
+                continue
+            }
 
             guard levelIndex < sortedLevels.count - 1 else {
                 result.append(contentsOf: outerPolygons)
@@ -58,7 +60,7 @@ enum AnnularAssembly {
             }
 
             let nextLevel = sortedLevels[levelIndex + 1]
-            let innerCandidates = grouped[nextLevel]!.map(IndexedPolygon.init)
+            let innerCandidates = grouped[nextLevel, default: []].map(IndexedPolygon.init)
 
             for outer in outerPolygons {
                 try Task.checkCancellation()

--- a/Sources/HeatMap/AnnularAssembly.swift
+++ b/Sources/HeatMap/AnnularAssembly.swift
@@ -5,6 +5,7 @@
 //  Created by Tom Hoag on 3/19/26.
 //
 
+import CoreGraphics
 import CoreLocation
 
 /// Assembles flat contour polygons into annular (ring-shaped) polygons
@@ -57,9 +58,11 @@ enum AnnularAssembly {
             }
 
             let nextLevel = sortedLevels[levelIndex + 1]
-            let innerCandidates = grouped[nextLevel]!
+            let innerCandidates = grouped[nextLevel]!.map(IndexedPolygon.init)
 
             for outer in outerPolygons {
+                try Task.checkCancellation()
+
                 let holes = findInteriorPolygons(
                     outer: outer,
                     candidates: innerCandidates
@@ -79,6 +82,23 @@ enum AnnularAssembly {
 
     // MARK: - Private
 
+    private struct IndexedPolygon {
+        let coordinates: [CLLocationCoordinate2D]
+        let firstVertex: CGPoint?
+
+        init(polygon: HeatMapPolygon) {
+            self.coordinates = polygon.coordinates
+            if let first = polygon.coordinates.first {
+                self.firstVertex = CGPoint(
+                    x: first.longitude,
+                    y: first.latitude
+                )
+            } else {
+                self.firstVertex = nil
+            }
+        }
+    }
+
     /// Finds which candidate polygons are spatially inside the outer
     /// polygon.
     ///
@@ -94,15 +114,40 @@ enum AnnularAssembly {
     ///   outer polygon.
     private static func findInteriorPolygons(
         outer: HeatMapPolygon,
-        candidates: [HeatMapPolygon]
+        candidates: [IndexedPolygon]
     ) -> [[CLLocationCoordinate2D]] {
         var holes: [[CLLocationCoordinate2D]] = []
+        let outerPath = makePath(from: outer.coordinates)
+        let outerBounds = outerPath.boundingBox
+
         for inner in candidates {
-            guard let firstVertex = inner.coordinates.first else { continue }
-            if outer.contains(firstVertex) {
+            guard let firstVertex = inner.firstVertex,
+                  outerBounds.contains(firstVertex) else {
+                continue
+            }
+
+            if outerPath.contains(firstVertex, using: .evenOdd) {
                 holes.append(inner.coordinates)
             }
         }
         return holes
+    }
+
+    /// Builds a Core Graphics path using longitude as x and latitude as y.
+    private static func makePath(from coordinates: [CLLocationCoordinate2D]) -> CGPath {
+        let path = CGMutablePath()
+        guard let first = coordinates.first else {
+            return path
+        }
+
+        path.move(to: CGPoint(x: first.longitude, y: first.latitude))
+        for coordinate in coordinates.dropFirst() {
+            path.addLine(to: CGPoint(
+                x: coordinate.longitude,
+                y: coordinate.latitude
+            ))
+        }
+        path.closeSubpath()
+        return path
     }
 }

--- a/Sources/HeatMap/DensityGrid.swift
+++ b/Sources/HeatMap/DensityGrid.swift
@@ -151,11 +151,12 @@ struct DensityGrid: Sendable {
 
         var grid = [Double](repeating: 0, count: rows * columns)
 
-        // Check cancellation every N points to balance responsiveness with overhead
-        let checkInterval = max(1, points.count / 100)
+        // Check cancellation periodically to balance responsiveness with overhead.
+        let pointCheckInterval = max(1, points.count / 100)
+        let rowCheckInterval = 8 // how often to check cancellation in the row hot path
 
         for (index, point) in points.enumerated() {
-            if index % checkInterval == 0 {
+            if index % pointCheckInterval == 0 {
                 try Task.checkCancellation()
             }
 
@@ -169,6 +170,10 @@ struct DensityGrid: Sendable {
             let colEnd = min(columns - 1, Int((pointLon + kernelRadiusLon - minLon) / lonStep))
 
             for row in rowStart...rowEnd {
+                if (row - rowStart) % rowCheckInterval == 0 {
+                    try Task.checkCancellation()
+                }
+
                 let cellLat = minLat + (Double(row) + 0.5) * latStep
                 let dy = (cellLat - pointLat) * GeoConversions.metersPerDegreeLat
                 let lonScale = GeoConversions.metersPerDegreeLon(at: cellLat)

--- a/Sources/HeatMap/HeatMapContours.swift
+++ b/Sources/HeatMap/HeatMapContours.swift
@@ -160,11 +160,17 @@ public struct HeatMapContours: Sendable, Equatable {
         from points: [P],
         configuration: HeatMapConfiguration = HeatMapConfiguration()
     ) async throws -> HeatMapContours {
+        try Task.checkCancellation()
         let points = Array(points)
         let configuration = configuration
-        return try await Task.detached {
+        let task = Task.detached {
             try computeCore(from: points, configuration: configuration)
-        }.value
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     // MARK: - Private

--- a/Sources/HeatMap/HeatMapContours.swift
+++ b/Sources/HeatMap/HeatMapContours.swift
@@ -164,7 +164,7 @@ public struct HeatMapContours: Sendable, Equatable {
         let points = Array(points)
         let configuration = configuration
         let task = Task.detached {
-            try computeCore(from: points, configuration: configuration)
+            try await computeCore(from: points, configuration: configuration)
         }
         return try await withTaskCancellationHandler {
             try await task.value
@@ -189,12 +189,7 @@ public struct HeatMapContours: Sendable, Equatable {
         let grid = try DensityGrid.compute(from: points, configuration: configuration)
 
         // 2. Resolve thresholds
-        let thresholds = configuration.levelSpacing.resolveThresholds(
-            levels: configuration.contourLevels,
-            minDensity: grid.minDensity,
-            maxDensity: grid.maxDensity,
-            densityValues: grid.values
-        )
+        let thresholds = resolveThresholds(for: grid, configuration: configuration)
 
         // 3. Contour extraction (checks between each level internally)
         let result = try MarchingSquares.extractContours(
@@ -202,8 +197,59 @@ public struct HeatMapContours: Sendable, Equatable {
             thresholds: thresholds
         )
 
+        return try finalize(
+            polygons: result,
+            thresholds: thresholds,
+            configuration: configuration
+        )
+    }
+
+    /// Async implementation used by the async compute entry point.
+    ///
+    /// The density grid is still built on the detached worker task, while
+    /// marching-squares row processing uses bounded Swift concurrency.
+    private static func computeCore<P: HeatMapable>(
+        from points: [P],
+        configuration: HeatMapConfiguration
+    ) async throws -> HeatMapContours {
+        // 1. Density grid (checks cancellation internally between points)
+        let grid = try DensityGrid.compute(from: points, configuration: configuration)
+
+        // 2. Resolve thresholds
+        let thresholds = resolveThresholds(for: grid, configuration: configuration)
+
+        // 3. Contour extraction (uses bounded child tasks for row chunks)
+        let result = try await MarchingSquares.extractContours(
+            from: grid,
+            thresholds: thresholds
+        )
+
+        return try finalize(
+            polygons: result,
+            thresholds: thresholds,
+            configuration: configuration
+        )
+    }
+
+    private static func resolveThresholds(
+        for grid: DensityGrid,
+        configuration: HeatMapConfiguration
+    ) -> [Double] {
+        configuration.levelSpacing.resolveThresholds(
+            levels: configuration.contourLevels,
+            minDensity: grid.minDensity,
+            maxDensity: grid.maxDensity,
+            densityValues: grid.values
+        )
+    }
+
+    private static func finalize(
+        polygons: [HeatMapPolygon],
+        thresholds: [Double],
+        configuration: HeatMapConfiguration
+    ) throws -> HeatMapContours {
         // 4. Smoothing (check between each polygon)
-        let smoothed = try result.map { polygon in
+        let smoothed = try polygons.map { polygon in
             try Task.checkCancellation()
             return HeatMapPolygon(
                 level: polygon.level,

--- a/Sources/HeatMap/HeatMapLayer.swift
+++ b/Sources/HeatMap/HeatMapLayer.swift
@@ -42,8 +42,8 @@ import SwiftUI
 ///
 /// - ``HeatMapContours``
 public struct HeatMapLayer: MapContent {
-    /// The contour polygons to render.
-    private let contours: [HeatMapPolygon]
+    /// The MapKit polygons to render.
+    private let polygons: [RenderablePolygon]
 
     /// The gradient used to color each contour level.
     private let gradient: HeatMapGradient
@@ -67,7 +67,13 @@ public struct HeatMapLayer: MapContent {
     ///   - contours: Pre-computed contour data.
     ///   - style: The visual styling (gradient, opacity, render mode).
     public init(contours: HeatMapContours, style: HeatMapStyle) {
-        self.contours = contours.polygons
+        self.polygons = contours.polygons.map { polygon in
+            RenderablePolygon(
+                id: polygon.id,
+                level: polygon.level,
+                polygon: Self.makeMKPolygon(from: polygon)
+            )
+        }
         self.gradient = style.gradient
         self.totalLevels = contours.levels
         self.fillOpacity = style.fillOpacity
@@ -86,11 +92,17 @@ public struct HeatMapLayer: MapContent {
 
     @MainActor
     public var body: some MapContent {
-        ForEach(contours) { polygon in
-            MapPolygon(Self.makeMKPolygon(from: polygon))
+        ForEach(polygons) { polygon in
+            MapPolygon(polygon.polygon)
                 .foregroundStyle(polygonFillColor(for: polygon.level))
                 .stroke(polygonStrokeColor(for: polygon.level), lineWidth: polygonStrokeLineWidth)
         }
+    }
+
+    private struct RenderablePolygon: Identifiable {
+        let id: UUID
+        let level: Int
+        let polygon: MKPolygon
     }
 
     // MARK: - Color Helpers

--- a/Sources/HeatMap/MarchingSquares.swift
+++ b/Sources/HeatMap/MarchingSquares.swift
@@ -20,8 +20,8 @@ import Foundation
 /// Saddle cases (where diagonally opposite corners are above the threshold)
 /// are disambiguated using the cell center value.
 ///
-/// Row processing is parallelized using `DispatchQueue.concurrentPerform`
-/// for performance on large grids.
+/// The async extraction path parallelizes row processing with bounded Swift
+/// concurrency for performance on large grids.
 ///
 /// ## Topics
 ///
@@ -29,6 +29,13 @@ import Foundation
 ///
 /// - ``extractContours(from:thresholds:)``
 enum MarchingSquares {
+    /// Upper bound for async row-chunk workers.
+    ///
+    /// Heat map generation is background CPU work in host apps that may also
+    /// be rendering MapKit overlays, parsing incoming data, or reconnecting
+    /// network streams. Keep this conservative and reserve at least one core
+    /// for the rest of the app.
+    private static let maximumConcurrentSegmentWorkers = 4
 
     // MARK: - Public
 
@@ -71,10 +78,62 @@ enum MarchingSquares {
         for (level, threshold) in thresholds.enumerated() {
             try Task.checkCancellation()
 
-            let segments = generateSegments(grid: grid, threshold: threshold)
+            let segments = try generateSegments(grid: grid, threshold: threshold)
             let rings = assembleRings(from: segments)
 
             for ring in rings {
+                let coordinates = ring.map { grid.coordinate(row: $0.row, col: $0.col) }
+                guard coordinates.count >= 3 else { continue }
+                allPolygons.append(
+                    HeatMapPolygon(
+                        level: level,
+                        threshold: threshold,
+                        coordinates: coordinates
+                    )
+                )
+            }
+        }
+
+        return allPolygons
+    }
+
+    /// Asynchronously extracts contour polygons from the density grid at the
+    /// given thresholds.
+    ///
+    /// This variant parallelizes segment generation with a bounded number of
+    /// child tasks so CPU work remains tied to Swift task cancellation and does
+    /// not fan out across every available core.
+    ///
+    /// - Parameters:
+    ///   - grid: The density grid to extract contours from.
+    ///   - thresholds: The density threshold values, sorted ascending.
+    /// - Returns: All extracted polygons, sorted from lowest level
+    ///   (outermost) to highest (innermost).
+    /// - Throws: `CancellationError` if the current task is cancelled.
+    static func extractContours(
+        from grid: DensityGrid,
+        thresholds: [Double]
+    ) async throws -> [HeatMapPolygon] {
+        guard grid.rows > 1, grid.columns > 1, !thresholds.isEmpty else {
+            return []
+        }
+
+        let range = grid.maxDensity - grid.minDensity
+        guard range > 0 else {
+            return []
+        }
+
+        var allPolygons: [HeatMapPolygon] = []
+
+        for (level, threshold) in thresholds.enumerated() {
+            try Task.checkCancellation()
+
+            let segments = try await generateSegments(grid: grid, threshold: threshold)
+            let rings = assembleRings(from: segments)
+
+            for ring in rings {
+                try Task.checkCancellation()
+
                 let coordinates = ring.map { grid.coordinate(row: $0.row, col: $0.col) }
                 guard coordinates.count >= 3 else { continue }
                 allPolygons.append(
@@ -152,9 +211,7 @@ enum MarchingSquares {
 
     /// Generates all directed edge segments for a given threshold.
     ///
-    /// Rows are processed in parallel using `DispatchQueue.concurrentPerform`.
-    /// Each row writes to its own slot in a pre-allocated `Array`, so no
-    /// synchronization is needed.
+    /// Rows are processed serially for the synchronous extraction path.
     ///
     /// - Parameters:
     ///   - grid: The density grid.
@@ -163,67 +220,141 @@ enum MarchingSquares {
     private static func generateSegments(
         grid: DensityGrid,
         threshold: Double
-    ) -> [Segment] {
+    ) throws -> [Segment] {
         let rowCount = grid.rows - 1
         guard rowCount > 0 else { return [] }
 
-        // Pre-allocate one slot per row. Each concurrent iteration writes
-        // only to its own index, so no synchronization is needed.
-        var rowSegments = Array(repeating: [Segment](), count: rowCount)
+        return try generateSegments(
+            grid: grid,
+            threshold: threshold,
+            inRows: 0..<rowCount
+        )
+    }
 
-        rowSegments.withUnsafeMutableBufferPointer { buffer in
-            // Safe: each concurrent iteration writes to a distinct index.
-            nonisolated(unsafe) let baseAddress = buffer.baseAddress!
-            DispatchQueue.concurrentPerform(iterations: rowCount) { row in
-                var localSegments: [Segment] = []
+    /// Generates all directed edge segments for a given threshold using
+    /// bounded Swift concurrency.
+    private static func generateSegments(
+        grid: DensityGrid,
+        threshold: Double
+    ) async throws -> [Segment] {
+        let rowCount = grid.rows - 1
+        guard rowCount > 0 else { return [] }
 
-                for col in 0..<(grid.columns - 1) {
-                    let tl = grid.value(row: row, col: col)
-                    let tr = grid.value(row: row, col: col + 1)
-                    let br = grid.value(row: row + 1, col: col + 1)
-                    let bl = grid.value(row: row + 1, col: col)
-
-                    var caseIndex = 0
-                    if tl >= threshold { caseIndex |= 8 }
-                    if tr >= threshold { caseIndex |= 4 }
-                    if br >= threshold { caseIndex |= 2 }
-                    if bl >= threshold { caseIndex |= 1 }
-
-                    // Skip cases with no edges
-                    guard caseIndex != 0, caseIndex != 15 else { continue }
-
-                    // Disambiguate saddle cases
-                    let edges: [(Int, Int)]
-                    if caseIndex == 5 {
-                        let center = (tl + tr + br + bl) / 4.0
-                        edges = center >= threshold ? saddleCase5Alt : edgeTable[5]
-                    } else if caseIndex == 10 {
-                        let center = (tl + tr + br + bl) / 4.0
-                        edges = center >= threshold ? saddleCase10Alt : edgeTable[10]
-                    } else {
-                        edges = edgeTable[caseIndex]
-                    }
-
-                    let corners = (tl: tl, tr: tr, br: br, bl: bl)
-
-                    for (edgeA, edgeB) in edges {
-                        let start = interpolateEdge(
-                            edge: edgeA, row: row, col: col,
-                            corners: corners, threshold: threshold
-                        )
-                        let end = interpolateEdge(
-                            edge: edgeB, row: row, col: col,
-                            corners: corners, threshold: threshold
-                        )
-                        localSegments.append(Segment(start: start, end: end))
-                    }
+        let ranges = rowRanges(rowCount: rowCount)
+        return try await withThrowingTaskGroup(of: RowSegments.self) { group in
+            for range in ranges {
+                group.addTask {
+                    let segments = try self.generateSegments(
+                        grid: grid,
+                        threshold: threshold,
+                        inRows: range
+                    )
+                    return RowSegments(startRow: range.lowerBound, segments: segments)
                 }
+            }
 
-                baseAddress.advanced(by: row).pointee = localSegments
+            var chunks: [RowSegments] = []
+            chunks.reserveCapacity(ranges.count)
+
+            for try await chunk in group {
+                chunks.append(chunk)
+            }
+
+            chunks.sort { $0.startRow < $1.startRow }
+            return chunks.flatMap(\.segments)
+        }
+    }
+
+    private struct RowSegments: Sendable {
+        let startRow: Int
+        let segments: [Segment]
+    }
+
+    private static func rowRanges(rowCount: Int) -> [Range<Int>] {
+        let workerCount = workerCount(forRows: rowCount)
+        guard workerCount > 1 else { return [0..<rowCount] }
+
+        let chunkSize = Int(ceil(Double(rowCount) / Double(workerCount)))
+        return stride(from: 0, to: rowCount, by: chunkSize).map { start in
+            start..<min(start + chunkSize, rowCount)
+        }
+    }
+
+    private static func workerCount(forRows rowCount: Int) -> Int {
+        let activeCores = ProcessInfo.processInfo.activeProcessorCount
+        let maxWorkers = max(1, min(activeCores - 1, maximumConcurrentSegmentWorkers))
+        return min(rowCount, maxWorkers)
+    }
+
+    private static func generateSegments(
+        grid: DensityGrid,
+        threshold: Double,
+        inRows rows: Range<Int>
+    ) throws -> [Segment] {
+        var result: [Segment] = []
+
+        for row in rows {
+            try Task.checkCancellation()
+            result.append(contentsOf: segmentsForRow(
+                row,
+                grid: grid,
+                threshold: threshold
+            ))
+        }
+
+        return result
+    }
+
+    private static func segmentsForRow(
+        _ row: Int,
+        grid: DensityGrid,
+        threshold: Double
+    ) -> [Segment] {
+        var localSegments: [Segment] = []
+
+        for col in 0..<(grid.columns - 1) {
+            let tl = grid.value(row: row, col: col)
+            let tr = grid.value(row: row, col: col + 1)
+            let br = grid.value(row: row + 1, col: col + 1)
+            let bl = grid.value(row: row + 1, col: col)
+
+            var caseIndex = 0
+            if tl >= threshold { caseIndex |= 8 }
+            if tr >= threshold { caseIndex |= 4 }
+            if br >= threshold { caseIndex |= 2 }
+            if bl >= threshold { caseIndex |= 1 }
+
+            // Skip cases with no edges
+            guard caseIndex != 0, caseIndex != 15 else { continue }
+
+            // Disambiguate saddle cases
+            let edges: [(Int, Int)]
+            if caseIndex == 5 {
+                let center = (tl + tr + br + bl) / 4.0
+                edges = center >= threshold ? saddleCase5Alt : edgeTable[5]
+            } else if caseIndex == 10 {
+                let center = (tl + tr + br + bl) / 4.0
+                edges = center >= threshold ? saddleCase10Alt : edgeTable[10]
+            } else {
+                edges = edgeTable[caseIndex]
+            }
+
+            let corners = (tl: tl, tr: tr, br: br, bl: bl)
+
+            for (edgeA, edgeB) in edges {
+                let start = interpolateEdge(
+                    edge: edgeA, row: row, col: col,
+                    corners: corners, threshold: threshold
+                )
+                let end = interpolateEdge(
+                    edge: edgeB, row: row, col: col,
+                    corners: corners, threshold: threshold
+                )
+                localSegments.append(Segment(start: start, end: end))
             }
         }
 
-        return rowSegments.flatMap { $0 }
+        return localSegments
     }
 
     /// Computes the interpolated point on a cell edge where the density


### PR DESCRIPTION
Sorry for the big PR, I can split these out if you like. I'm using HeatMap in a macOS app I'm building and ran in to a few performance issues with my use case. These are some targeted fixes that don't change the API surface area, just makes changes "under the hood."

This adds a few more places for task cancellation on larger kernels, and propagates task cancellation through to the detached compute task. This makes the `asyncComputeThrowsWhenCancelled()` test now complete almost instantly instead of waiting for the inner task to complete (~10s).

SwiftUI could churn quite a bit on updates (I update a map fairly frequently with changing data) and after 10-15 minutes SwiftUI would enter a vectorkit.layoutqueue spin. This is mitigated by not triggering re-renders if the contours haven't changed by using an identifiable `RenderablePolygon` type. 

The `.concurrentPerform(iterations: rowCount)` call would also saturate my macOS machine with a storm of updates. On iOS since the app is front and center this is probably not a big deal, but on macOS this would cause large spikes on all cores, starving other processes. Which is odd because the docs call out "To get the maximum benefit of this function, configure the number of iterations to be at least three times the number of available cores." 🤷‍♂️ . I replaced this call with a concurrentTaskGroup and moved the async `compute` path to use Swift's concurrency model. This also gets around the `.withUnsafeMutableBufferPointer` (even though it is safe). The `maximumConcurrentSegmentWorkers` is set at four, but can be changed if needed. On my M1 Max it seemed to give the best trade-offs.

Finally when computing holes, I use CoreGraphics to build the polys and bounding boxes and use their `.contains` functions instead of raycasting. This is just for early rejection of the larger, outer polygon. It sped up a hot loop I caught a few times in Instruments.